### PR TITLE
Allow multiple variable repetition

### DIFF
--- a/lib/auto-copyright.coffee
+++ b/lib/auto-copyright.coffee
@@ -11,7 +11,7 @@ class AutoCopyright
   # Returns a {String} with the raw copyright text.
   getCopyrightText: ->
     text = "#{atom.config.get('auto-copyright.template')}\n"
-    text = text.replace('%y', @getYear()).replace('%o', atom.config.get('auto-copyright.owner'))
+    text = text.replace(/%y/g, @getYear()).replace(/%o/g, atom.config.get('auto-copyright.owner'))
 
     @wrap(text, atom.config.get('auto-copyright.buffer'))
 


### PR DESCRIPTION
This quick code improvement should allow variables repetition inside the template.

```
Eg.
Copyright (c) %y by %o. All Rights Reserved.
This code may only be used under the MIT style license found at ttps://%o.mit-license.org/@%y/
```
