### PR TITLE
Fix #21. Fix uncaught type error.Expected an object with start and end properties

### DIFF
--- a/lib/auto-copyright.coffee
+++ b/lib/auto-copyright.coffee
@@ -31,7 +31,8 @@ class AutoCopyright
   hasCopyright: (obj) ->
     return @hasCopyright(obj.buffer) if obj.buffer?
 
-    @hasCopyrightInText(obj.getTextInRange([[0, 0], [10, 0]]))
+    unless Object.keys(obj).length is 0
+      @hasCopyrightInText(obj.getTextInRange([[0, 0], [10, 0]]))
 
   # Private: Determines if the supplied text has a copyright notice.
   #


### PR DESCRIPTION
This change is a quick fix for the issue (uncaught type error. expected an object with start and end properties) by checking for the empty object. (Replicated this issue on Mac OS X)

Fix #21.