### PR TITLE
Fix broken tests and deprecations

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright &copy; 2014-2015 [Lee Dohm](http://www.lee-dohm.com), [Lifted Studios](http://www.liftedstudios.com)
+Copyright &copy; 2014-2015, 2017 [Lee Dohm](http://www.lee-dohm.com), [Lifted Studios](http://www.liftedstudios.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ Multi-line templates *are* supported. At the time of this writing, Atom's Settin
 
 No keybindings are assigned by default.
 
-## Copyright
+## License
 
-Copyright &copy; 2014-2015 [Lee Dohm](http://www.lee-dohm.com), [Lifted Studios](http://www.liftedstudios.com). See [LICENSE](https://github.com/lee-dohm/auto-copyright/blob/master/LICENSE.md) for details.
+[MIT](LICENSE.md)

--- a/lib/auto-copyright.coffee
+++ b/lib/auto-copyright.coffee
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2015 by Lifted Studios. All Rights Reserved.
 #
 
+{TextBuffer} = require 'atom'
 YearRange = require './year-range'
 
 # Public: Utilities for placing and updating copyright notices.
@@ -29,7 +30,7 @@ class AutoCopyright
   #
   # Returns a {Boolean} indicating whether this buffer has a copyright notice.
   hasCopyright: (obj) ->
-    return @hasCopyright(obj.buffer) if obj.buffer?
+    return @hasCopyright(obj.buffer) if obj.buffer? and obj.buffer instanceof TextBuffer
 
     @hasCopyrightInText(obj.getTextInRange([[0, 0], [10, 0]]))
 
@@ -71,7 +72,7 @@ class AutoCopyright
   # * `editor` {TextEditor} where the cursor is.
   # * `callback` A {Function} that manipulates the cursor position.
   restoreCursor: (editor, callback) ->
-    marker = editor.markBufferPosition(editor.getCursorBufferPosition(), persistent: false)
+    marker = editor.markBufferPosition(editor.getCursorBufferPosition())
 
     callback()
 

--- a/lib/auto-copyright.coffee
+++ b/lib/auto-copyright.coffee
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 by Lifted Studios. All Rights Reserved.
+# Copyright (c) 2014-2015, 2017 by Lifted Studios. All Rights Reserved.
 #
 
 {TextBuffer} = require 'atom'


### PR DESCRIPTION
`hasCopyright` was originally designed to work on `TextBuffer` objects. Originally, `TextEditors` had a `buffer` property but `TextBuffers` didn't. Now `TextBuffer` objects have a `buffer` property too that is pointing to an empty object, which was causing `hasCopyright` to fail. Redesigned the `hasCopyright` function to execute on the first `TextBuffer` object it finds.

Passing `persistent: false` to `TextEditor.markBufferPosition` is now deprecated, so I removed it. Things seem to still work :grinning:

Fixes #21 